### PR TITLE
Issue #8: Add *.egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .cursor/
 .envbuild/
 .env
+*.egg-info/


### PR DESCRIPTION
This PR adds the *.egg-info pattern to .gitignore to properly ignore Python package build artifacts. Closes #8.